### PR TITLE
HELP? - 2.2.8 is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Keepalived
+# Keepalived 
 
 [![trivy](https://github.com/visibilityspots/dockerfile-keepalived/actions/workflows/trivy.yml/badge.svg)](https://github.com/visibilityspots/dockerfile-keepalived/actions/workflows/trivy.yml)
 [![docker-hub-description](https://github.com/visibilityspots/dockerfile-keepalived/actions/workflows/docker-hub-description.yml/badge.svg)](https://github.com/visibilityspots/dockerfile-keepalived/actions/workflows/docker-hub-description.yml)


### PR DESCRIPTION
(Hi, opening a pull request because it seems like issues are disabled on this repo, I didn't see another way to get in touch)

Just wanted to let you know, we were using docker image visibilityspots/keepalived:2.2.8. A few days ago, this image seems to have been deleted. I found out when we tried to do a deploy to one of our production setups.

I tried v2.2.8, but, it seems to contain heavy breaking changes from the previous version and causes errors on startup.

Is there any chance as a quick fix, we can get the original 2.2.8 version back up temporarily to give a chance to migrate to the new container?

Maybe in the future the containers could be named keepalived-2.2.8:v1.0.0 for the original and keepalived-2.2.8:v2.0.0 to distinguish between the version# of keepalived vs the version# of the docker container build / config files / etc?

I may try and spin up a fork here real quick to get that going. Anything you can do to help would be appreciated.